### PR TITLE
Ctrl + R to rename symbol

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,6 +141,11 @@
         "key": "alt+right",
         "command": "workbench.action.navigateForward",
         "when": "canNavigateForward"
+      },
+      {
+        "key": "ctrl+r",
+        "command": "editor.action.rename",
+        "when": "editorHasRenameProvider && editorTextFocus && !editorReadonly"
       }
     ]
   }


### PR DESCRIPTION
Completely forgot that that was how I renamed variables back then in Netbeans, but it was still in my muscle memory.