### PR TITLE
Ctrl+7 shows navigator (e.g. outline) in NetBeans

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Keymap
 |alt+shift+up              |editor.action.moveLinesUpAction|
 |ctrl+1                    |workbench.view.explorer|
 |ctrl+shift+1              |workbench.files.action.focusOpenEditorsView|
+|ctrl+7                    |outline.focus|
 |ctrl+shift+0              |workbench.action.focusActiveEditorGroup|
 |ctrl+u u                  |editor.action.transformToUppercase|
 |ctrl+u l                  |editor.action.transformToLowercase|

--- a/package.json
+++ b/package.json
@@ -68,6 +68,10 @@
         "command": "workbench.files.action.focusOpenEditorsView"
       },
       {
+        "key": "ctrl+7",
+        "command": "outline.focus"
+      },
+      {
         "key": "ctrl+u u",
         "command": "editor.action.transformToUppercase",
         "when": "editorTextFocus && !editorReadonly"


### PR DESCRIPTION
- I am used to jump to NetBeans Navigator - e.g. VSCode Outline view by pressing `Ctrl+7`
- here is a change that donates the shortcut to your extension
- I am not sure how to build the extension - so I haven't really tested my change
- Thanks for helping NetBeans users trying VSCode